### PR TITLE
chore(nginx): using nginx as api_gateway

### DIFF
--- a/micro-apigateway/nginx.conf
+++ b/micro-apigateway/nginx.conf
@@ -44,5 +44,4 @@ server {
     location /uppercase/ {
         proxy_pass http://uppercase-backend/;
     }
-
 }


### PR DESCRIPTION
This PR uses Nginx web-server as the API Gateway at the backend